### PR TITLE
Closes issue #58

### DIFF
--- a/src/lib/Fullpage.svelte
+++ b/src/lib/Fullpage.svelte
@@ -11,6 +11,7 @@
     export let disableDragNavigation = false
     export let disableArrowsNavigation = false
     export let easing: (t: number) => number | null = quartOut
+    export let dragThreshold:number = 50
 
     const sectionCount = writable(0)
     const activeSectionStore = FullpageActivity(sectionCount)
@@ -38,14 +39,15 @@
             pageRoundingThresholdMultiplier,
             disableDragNavigation,
             disableArrowsNavigation,
-            easing
+            easing,
+            dragThreshold
         }
     })
 </script>
 
 <div {...$$restProps}>
     <FullpageController bind:toSection {activeSectionStore} {scrollDuration} {pageRoundingThresholdMultiplier}
-                        {disableDragNavigation} {disableArrowsNavigation} {easing}>
+                        {disableDragNavigation} {disableArrowsNavigation} {easing} {dragThreshold}>
         <slot/>
     </FullpageController>
     <Indicator {sections} activeSection={$activeSectionStore} on:goto={toSection}/>

--- a/src/lib/Fullpage.svelte
+++ b/src/lib/Fullpage.svelte
@@ -11,7 +11,7 @@
     export let disableDragNavigation = false
     export let disableArrowsNavigation = false
     export let easing: (t: number) => number | null = quartOut
-    export let dragThreshold:number = 50
+    export let dragThreshold: number = 50
 
     const sectionCount = writable(0)
     const activeSectionStore = FullpageActivity(sectionCount)

--- a/src/lib/FullpageController.svelte
+++ b/src/lib/FullpageController.svelte
@@ -101,7 +101,6 @@
     const handleDragEnd = () => {
         if (tapped) return
         dragging = false
-        // quick fix is to add -1 to hasScrolledUp
         const hasScrolledUp = dragStartScroll > fullpage.scrollTop
         const scrollDelta = (hasScrolledUp ? fullpage.scrollTop - fullpage.clientHeight : fullpage.scrollTop) % fullpage.clientHeight
         const hasExceededScrollRoundThreshold = Math.abs(scrollDelta) > fullpage.clientHeight / pageRoundingThresholdMultiplier

--- a/src/lib/FullpageController.svelte
+++ b/src/lib/FullpageController.svelte
@@ -9,6 +9,7 @@
     export let disableArrowsNavigation: boolean
     export let pageRoundingThresholdMultiplier: number
     export let easing: (t: number) => number
+    export let dragThreshold: number = 50
 
     let fullpage
     const fullpageScroll = tweened(0, {
@@ -22,8 +23,7 @@
     let dragStartScroll = 0
     let dragging
     let tapped = false
-    // maybe make this user configurable?
-    let dragThreshold = 50
+
 
     const scrollUp = () => {
         activeSectionStore.previousPage()

--- a/src/lib/FullpageController.svelte
+++ b/src/lib/FullpageController.svelte
@@ -56,7 +56,7 @@
         if (!disableArrowsNavigation) {
             switch (event.key) {
             case 'ArrowDown':
-                    scrollDown()
+                scrollDown()
                     break
                 case 'ArrowUp':
                 scrollUp()

--- a/src/lib/FullpageController.svelte
+++ b/src/lib/FullpageController.svelte
@@ -21,6 +21,9 @@
     let dragPosition = 0
     let dragStartScroll = 0
     let dragging
+    let tapped = false
+    // maybe make this user configurable?
+    let dragThreshold = 50
 
     const scrollUp = () => {
         activeSectionStore.previousPage()
@@ -47,17 +50,18 @@
     }
 
     const handleKey = (event) => {
+        console.log('event.key: ', event.key)
         if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
             event.preventDefault()
         }
         if (!disableArrowsNavigation) {
             switch (event.key) {
-            case 'ArrowDown':
-                scrollDown()
-                break
-            case 'ArrowUp':
-                scrollUp()
-                break
+                case 'ArrowDown':
+                    scrollDown()
+                    break
+                case 'ArrowUp':
+                    scrollUp()
+                    break
             }
         }
     }
@@ -81,13 +85,23 @@
     }
     const handleDragging = (event) => {
         if (dragging) {
-            fullpageScroll.set(dragStartScroll - (event.clientY - dragPosition), {
-                duration: 0
-            })
+            const distance = Math.abs(event.clientY - dragPosition);
+            const threshold = distance > (fullpage.clientHeight / dragThreshold);
+
+            if (threshold) {
+                tapped = false;
+                const scrollAmount = dragStartScroll - (event.clientY - dragPosition);
+                fullpageScroll.set(scrollAmount, { duration: 0 });
+            } else {
+                tapped = true;
+            }
         }
-    }
+    };
+
     const handleDragEnd = () => {
+        if (tapped) return
         dragging = false
+        // quick fix is to add -1 to hasScrolledUp
         const hasScrolledUp = dragStartScroll > fullpage.scrollTop
         const scrollDelta = (hasScrolledUp ? fullpage.scrollTop - fullpage.clientHeight : fullpage.scrollTop) % fullpage.clientHeight
         const hasExceededScrollRoundThreshold = Math.abs(scrollDelta) > fullpage.clientHeight / pageRoundingThresholdMultiplier

--- a/src/lib/FullpageController.svelte
+++ b/src/lib/FullpageController.svelte
@@ -58,7 +58,7 @@
             case 'ArrowDown':
                 scrollDown()
                 break
-                case 'ArrowUp':
+            case 'ArrowUp':
                 scrollUp()
                 break
             }

--- a/src/lib/FullpageController.svelte
+++ b/src/lib/FullpageController.svelte
@@ -59,7 +59,7 @@
                     scrollDown()
                     break
                 case 'ArrowUp':
-                    scrollUp()
+                scrollUp()
                     break
             }
         }

--- a/src/lib/FullpageController.svelte
+++ b/src/lib/FullpageController.svelte
@@ -50,7 +50,6 @@
     }
 
     const handleKey = (event) => {
-        console.log('event.key: ', event.key)
         if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
             event.preventDefault()
         }

--- a/src/lib/FullpageController.svelte
+++ b/src/lib/FullpageController.svelte
@@ -57,7 +57,7 @@
             switch (event.key) {
             case 'ArrowDown':
                 scrollDown()
-                    break
+                break
                 case 'ArrowUp':
                 scrollUp()
                 break

--- a/src/lib/FullpageController.svelte
+++ b/src/lib/FullpageController.svelte
@@ -9,7 +9,7 @@
     export let disableArrowsNavigation: boolean
     export let pageRoundingThresholdMultiplier: number
     export let easing: (t: number) => number
-    export let dragThreshold: number = 50
+    export let dragThreshold: number
 
     let fullpage
     const fullpageScroll = tweened(0, {

--- a/src/lib/FullpageController.svelte
+++ b/src/lib/FullpageController.svelte
@@ -103,7 +103,6 @@
             setScroll()
             return
         }
-        dragging = false
         const hasScrolledUp = dragStartScroll > fullpage.scrollTop
         const scrollDelta = (hasScrolledUp ? fullpage.scrollTop - fullpage.clientHeight : fullpage.scrollTop) % fullpage.clientHeight
         const hasExceededScrollRoundThreshold = Math.abs(scrollDelta) > fullpage.clientHeight / pageRoundingThresholdMultiplier

--- a/src/lib/FullpageController.svelte
+++ b/src/lib/FullpageController.svelte
@@ -60,7 +60,7 @@
                     break
                 case 'ArrowUp':
                 scrollUp()
-                    break
+                break
             }
         }
     }

--- a/src/lib/FullpageController.svelte
+++ b/src/lib/FullpageController.svelte
@@ -55,7 +55,7 @@
         }
         if (!disableArrowsNavigation) {
             switch (event.key) {
-                case 'ArrowDown':
+            case 'ArrowDown':
                     scrollDown()
                     break
                 case 'ArrowUp':

--- a/src/lib/FullpageController.svelte
+++ b/src/lib/FullpageController.svelte
@@ -98,7 +98,11 @@
     };
 
     const handleDragEnd = () => {
-        if (tapped) return
+        dragging = false // Has to be set first when drag ends
+        if (tapped) {
+            setScroll()
+            return
+        }
         dragging = false
         const hasScrolledUp = dragStartScroll > fullpage.scrollTop
         const scrollDelta = (hasScrolledUp ? fullpage.scrollTop - fullpage.clientHeight : fullpage.scrollTop) % fullpage.clientHeight


### PR DESCRIPTION
# Closes #58 

## Changes made:
- Adjusted `handleDragging()` function to check for distance dragged.
- Added `dragThreshold` variable to set the intensity of the drag effect (Default is 50).
- Added `tapped` variable to check if distance of drag < threshold.

## Notes:
`dragThreshold` is exported and can be used like:

```html
<Fullpage dragThreshold={100}>
    ...
</Fullpage>
```

The quick way to fix this is also to do the following in `FullpageController.svelte`:
```ts
const handleDragEnd = () => {
        const hasScrolledUp = dragStartScroll > fullpage.scrollTop - 1 // append - 1 to offset the tap, thus disabling scroll
    ...
}
```
I was unsure if this would bring up more issues/outliers later, so I didn't implement it this way.
I also found it easier to implement the sensitivity (`dragThreshold`) using the `handleDragging()` function as opposed to the above fix.